### PR TITLE
feat: support command mode and more

### DIFF
--- a/lua/line-number-change-mode/init.lua
+++ b/lua/line-number-change-mode/init.lua
@@ -7,11 +7,10 @@ function M.setup(opts)
       clear = true,
    })
 
-   local line_number_map = opts
 
    local function set_hl_for_mode(mode)
-      if line_number_map[mode] then
-         vim.api.nvim_set_hl(0, "CursorLineNr", line_number_map[mode])
+      if opts[mode] then
+         vim.api.nvim_set_hl(0, "CursorLineNr", opts[mode])
 
          -- Have to force a redraw to repaint line number if switching to cmd mode
          if mode == "c" then

--- a/lua/line-number-change-mode/init.lua
+++ b/lua/line-number-change-mode/init.lua
@@ -4,26 +4,30 @@ function M.setup(opts)
    opts = opts or {}
 
    local group = vim.api.nvim_create_augroup("LineNumberChangeMode", {
-      clear = true
+      clear = true,
    })
 
-   vim.api.nvim_create_autocmd('ModeChanged', {
-      group = group,
-      callback = function()
-         local new_mode = vim.v.event.new_mode
-         local line_number_map = {
-            i = opts.i and opts.i or nil,
-            n = opts.n and opts.n or nil,
-            no = opts.no and opts.no or nil,
-            R = opts.R and opts.R or nil,
-            v = opts.n and opts.v or nil,
-            V = opts.V and opts.V or nil,
-         }
+   local line_number_map = opts
 
-         if line_number_map[new_mode] ~= nil and opts[new_mode] ~= nil then
-            vim.api.nvim_set_hl(0, 'CursorLineNr', line_number_map[new_mode])
+   local function set_hl_for_mode(mode)
+      if line_number_map[mode] then
+         vim.api.nvim_set_hl(0, "CursorLineNr", line_number_map[mode])
+
+         -- Have to force a redraw to repaint line number if switching to cmd mode
+         if mode == "c" then
+            vim.cmd.redraw()
          end
       end
+   end
+
+   -- set mode on setup to set CursorLineNr in case it's not already set
+   set_hl_for_mode(vim.api.nvim_get_mode().mode)
+
+   vim.api.nvim_create_autocmd("ModeChanged", {
+      group = group,
+      callback = function()
+         set_hl_for_mode(vim.v.event.new_mode)
+      end,
    })
 end
 


### PR DESCRIPTION
Nice plugin! I wanted to add support for command mode and cleaned up a few things along the way. Hope that's ok!

Have to force a redraw when switching to command mode (since nvim doesn't redraw the line number otherwise)
Just use opts as the map (also fixes small bug with v not being set if normal weren't set)
Set CursorLineNr on setup in case it's not set correctly already