### PR TITLE
Fix #7 Show correct hl after Telescope file open, Implement #9 Only show the mode highlight in the active window

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ return {
 
 It's off by defaut, but if you set `hide_inactive_cursorline = true`, then this plugin will hide the cursorline for inactive windows so the mode highlight will only be shown in the currently active window:
 
+![Screenshot 2024-10-24 at 12 16 58](https://github.com/user-attachments/assets/2286df66-af72-43e7-b4fc-305f696ad206)
 
 Note: if you're lazy loading this plugin and want to hide inactive window cursorlines, make sure `event` is either set to `VeryLazy` or as follows:
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,25 @@ return {
                     fg = palette.mantle,
                     bold = true,
                 },
-            }
+            },
+            hide_inactive_cursorline = false,
         })
     end
+}
+```
+
+## Hiding inactive cursorlines
+
+It's off by defaut, but if you set `hide_inactive_cursorline = true`, then this plugin will hide the cursorline for inactive windows so the mode highlight will only be shown in the currently active window:
+
+
+Note: if you're lazy loading this plugin and want to hide inactive window cursorlines, make sure `event` is either set to `VeryLazy` or as follows:
+
+```lua
+return {
+  'sethen/line-number-change-mode.nvim',
+  event = { 'ModeChanged', 'WinEnter', 'WinLeave' },
+...
 }
 ```
 


### PR DESCRIPTION
Fixes #7 
Implements #9 

`hide_active_cursorline` is off by default